### PR TITLE
device_state_attributes deprecated

### DIFF
--- a/custom_components/yandex_station/switch.py
+++ b/custom_components/yandex_station/switch.py
@@ -46,7 +46,7 @@ class YandexSwitch(SwitchEntity):
         return self._is_on
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return self._attrs
 
     async def async_update(self):


### PR DESCRIPTION
Replace Entity.device_state_attributes with Entity.extra_state_attributes
https://github.com/home-assistant/core/pull/47304

In my HA logs I can see
Entity media_player.yandex_station_xxxxxx (<class 'custom_components.yandex_station.media_player.YandexStationHDMI'>) implements device_state_attributes. Please report it to the custom component author.
Entity media_player.yandex_station_yyyyyyy (<class 'custom_components.yandex_station.media_player.YandexStation'>) implements device_state_attributes. Please report it to the custom component author.