### PR TITLE
Fix load cookies from config entry

### DIFF
--- a/custom_components/yandex_station/core/yandex_session.py
+++ b/custom_components/yandex_station/core/yandex_session.py
@@ -107,7 +107,7 @@ class YandexSession:
         self.music_token = music_token
         if cookie:
             raw = base64.b64decode(cookie)
-            self.session.cookie_jar._cookie = pickle.loads(raw)
+            self.session.cookie_jar._cookies = pickle.loads(raw)
 
         self._update_listeners = []
 


### PR DESCRIPTION
Исправлена опечатка, из-за которой при каждой загрузке компонента происходит повторная авторизация в методе `YandexSession.refresh_cookies`

В CookieJar куки хранятся в атрибуте `_cookies`, а не `_cookie` - https://github.com/aio-libs/aiohttp/blob/7d78fd01dbe983d119141d7f2775aefd42494f99/aiohttp/cookiejar.py#L68