### PR TITLE
Handle update of offline AC

### DIFF
--- a/custom_components/yandex_station/climate.py
+++ b/custom_components/yandex_station/climate.py
@@ -197,4 +197,7 @@ class YandexClimate(ClimateEntity):
 
             instance = property["parameters"]["instance"]
             if instance == "temperature":
-                self._c_temp = property["state"]["value"]
+                if property["state"] is not None:
+                    self._c_temp = property["state"]["value"]
+                else:
+                    self._c_temp = None


### PR DESCRIPTION
Если кондиционер выключен, то `property["state"] is None`.

Добавил обработку этого случая, чтобы не вылетало исключение во время добавления устройства.