### PR TITLE
Добавлена поддержка режимов в класс YandexLight

### DIFF
--- a/custom_components/yandex_station/core/yandex_quasar.py
+++ b/custom_components/yandex_station/core/yandex_quasar.py
@@ -22,6 +22,7 @@ IOT_TYPES = {
     "input_source": "devices.capabilities.mode",
     "brightness": "devices.capabilities.range",
     "color": "devices.capabilities.color_setting",
+    "scene": "devices.capabilities.color_setting",
     "work_speed": "devices.capabilities.mode",
     "humidity": "devices.capabilities.range",
     "ionization": "devices.capabilities.toggle",


### PR DESCRIPTION
В этом PR реализована поддержка режимов (сцен), таких как "Алиса", "Вечеринка", "Ночь" и тд, в дополнение к уже существующим эффектам цвета в классе YandexLight. Это позволит пользователям Home Assistant использовать предустановленные сцены для управления освещением через Яндекс устройства.

![Снимок экрана 2023-11-22 120453](https://github.com/AlexxIT/YandexStation/assets/6388201/87fc8535-53ed-4f66-aa77-da0a45e582e9)

1. Добавлен атрибут `_scenes`: Этот атрибут хранит доступные сцены, полученные от устройства. 

1. Переименован атрибут `_effects` в `_colors` для ясности

1. Модифицирован метод `effect_list`: Теперь этот метод возвращает список, состоящий как из эффектов цвета, так и из сцен, позволяя пользователю выбирать из более широкого спектра опций.

1. Расширен метод `async_added_to_hass`: Добавлена логика для извлечения сцен из данных устройства и их сохранения в атрибут `_scenes`.

1. Обновлен метод `async_turn_on`: Метод теперь поддерживает активацию сцен в дополнение к изменению цвета. Если выбранный эффект найден среди цветов, он отправляется как цветовой эффект, в противном случае - как сцена.

Так же добавлена поддержка отображения текущего эффекта
![Снимок экрана 2023-11-25 195931](https://github.com/AlexxIT/YandexStation/assets/6388201/0bf20294-f873-41e1-bb4f-7ae257cd7f03)
