### PR TITLE
Добавлена Яндекс Станция Миди как cucumber для регулировки яркости экрана

### DIFF
--- a/custom_components/yandex_station/media_player.py
+++ b/custom_components/yandex_station/media_player.py
@@ -377,7 +377,7 @@ class YandexStationBase(MediaBrowser):
         )
 
     async def _set_brightness(self, value: str):
-        if self.device_platform not in ("yandexstation_2", "yandexmini_2"):
+        if self.device_platform not in ("yandexstation_2", "yandexmini_2", "cucumber"):
             _LOGGER.warning("Поддерживаются только станции с экраном")
             return
 


### PR DESCRIPTION
В данном PR  добавлена колонка Миди в условие для регулировки яркостью экрана. 
Функция проверена и все работает.