### PR TITLE
fix(yandex_station): handle null media_position_updated_at in lyrics …

### DIFF
--- a/custom_components/yandex_station/camera.py
+++ b/custom_components/yandex_station/camera.py
@@ -103,7 +103,12 @@ class YandexLyrics(Camera):
         while entity.media_content_id == content_id:
             media_position = entity.media_position
             if entity.state == MediaPlayerState.PLAYING:
-                dt = datetime.now(UTC) - entity.media_position_updated_at
+                dt = (
+                    (datetime.now(UTC) - entity.media_position_updated_at)
+                    if entity.media_position_updated_at
+                    else datetime.now(UTC)
+                )
+
                 media_position += dt.total_seconds()
                 delay = min(lyric_pos_next - media_position, 1)
             else:


### PR DESCRIPTION
```
File "/config/custom_components/yandex_station/camera.py", line 70, in handle_async_mjpeg_stream
    await self.handle_lyrics(response, lyrics, self.lyrics_content_id)
  File "/config/custom_components/yandex_station/camera.py", line 106, in handle_lyrics
    dt = datetime.now(UTC) - entity.media_position_updated_at
         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'
```