### PR TITLE
Improved display of data when casting on chromecast devices

### DIFF
--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -1004,8 +1004,15 @@ class YandexStation(YandexStationBase):
             "media_content_type": source.get("media_content_type", "music"),
             "entity_id": source["entity_id"],
             "extra": {
-                "title": f"{self._attr_media_artist} - {self._attr_media_title}",
-                "thumb": self._attr_media_image_url,
+                "stream_type": "BUFFERED",
+                "metadata": {
+                    "metadataType": 3,
+                    "title": f"{self._attr_media_title}",
+                    "artist": f"{self._attr_media_artist}",
+                    "images": [{
+                        "url": self._attr_media_image_url
+                    }]
+                }
             },
         }
 


### PR DESCRIPTION
Привел ``extra`` параметры в соответствии с документацией из [HA](https://www.home-assistant.io/integrations/cast/) и [google](https://developers.google.com/cast/docs/media/messages#MediaInformation).
Постер, название трека и артист стали нормально отображаться на экране.
Протестировано на 2 ТВ philips c android tv.