### PR TITLE
Fixed proxying with ``Range`` header

### DIFF
--- a/custom_components/yandex_station/core/utils.py
+++ b/custom_components/yandex_station/core/utils.py
@@ -464,10 +464,12 @@ class StreamingView(HomeAssistantView):
         async with self.session.head(url, headers=headers) as r:
             response = web.Response(status=r.status)
             response.headers.update(r.headers)
+            
             # important for DLNA players
             response.headers.update({
                 "Content-Type": MIME_TYPES[ext],
             })
+            
             if not rng:
                 response.headers.update({
                     "Accept-Ranges": "bytes",
@@ -486,13 +488,17 @@ class StreamingView(HomeAssistantView):
             async with self.session.get(url, headers=headers) as r:
                 response = web.StreamResponse(status=r.status)
                 response.headers.update(r.headers)
+
+                # important for DLNA players
                 response.headers.update({
                     "Content-Type": MIME_TYPES[ext],
                 })
+                
                 if not rng:
                     response.headers.update({
                         "Accept-Ranges": "bytes",
                     })
+                
                 await response.prepare(request)
 
                 # same chunks as default web.FileResponse


### PR DESCRIPTION
1. Если клиент отправляет ``Range`` заголовок, то ожидается, что валидный ответ будет с кодом 206.
2. Некоторые клиенты, делая HEAD запрос, могут включать в него заголовок ``Range``, ожидая в ответ валидный ответ с заголовками ``Content-length``, ``Content-Range`` и кодом 206.

PR исправляет это, т.к. сейчас в ответ на запрос с ``Range`` ответ прилетает с кодом 200.
В плане функционала, корректно начинает работать перемотка треков и лечит зависание треков (после разрыва соединения хостом) на хромкаст устройствах (см. upd к [комментарию](https://github.com/AlexxIT/YandexStation/issues/594#issuecomment-2576476982)).