### PR TITLE
Fix change track, while playing to AirPlay receivers issue 594

### DIFF
--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -984,6 +984,19 @@ class YandexStation(YandexStationBase):
 
         source = self.sync_sources[self._attr_source]
 
+        #For AirPlay receivers is not possible to change media_content_id, while streaming to device is in progress
+        #So we need to send media_stop command to media_player instance
+        #And after streaming is stopped we can send to device new media_content_id
+        #If we don't do this we got error "already streaming to device"
+        #Error provided by pyatv component https://github.com/postlund/pyatv
+        #https://github.com/postlund/pyatv/blob/master/pyatv/protocols/raop/__init__.py at line 132
+        data_stop = {
+            "entity_id": source["entity_id"],
+        }
+        await self.hass.services.async_call("media_player", "media_stop", data_stop)
+        #After command is sended, we need to wait while receiver accept command and stop streaming
+        await asyncio.sleep(1)
+        
         try:
             info = await get_file_info(
                 self.quasar.session,


### PR DESCRIPTION
Fix issue Issue #594

When playing on AirPlay receivers (for example, HomePod), after changing a track, the new track is not played on the AirPlay receiver.
The problem is with the _pyatv_ component https://github.com/postlund/pyatv
The component returns the error "already streaming to device"
This error is generated https://github.com/postlund/pyatv/blob/master/pyatv/protocols/raop/__init__.py#L132
To fix this, we need to stop streaming to the device completely before sending the new _media_content_id_ to the AirPlay receiver, and only after that we can send the new _media_content_id_ and try to play it using _play_media_.