### PR TITLE
Allow getting hass external IP for https support

### DIFF
--- a/custom_components/yandex_station/core/stream.py
+++ b/custom_components/yandex_station/core/stream.py
@@ -95,7 +95,7 @@ class StreamView(HomeAssistantView):
         StreamView.key = secrets.token_hex()
 
         try:
-            StreamView.hass_url = network.get_url(hass, allow_external=False)
+            StreamView.hass_url = network.get_url(hass, allow_external=True)
             _LOGGER.debug(f"Локальный адрес Home Assistant: {StreamView.hass_url}")
         except Exception as e:
             _LOGGER.warning(f"Ошибка получения локального адреса Home Assistant: {e}")


### PR DESCRIPTION
При использовании аддона DuckDNS с Let's Encrypt возникает ошибка получения локального адреса, не производятся на Станцию файлы из Home Assistant Media. Отход от внутреннего IP позволяет решить эту проблему.
#689 