### PR TITLE
Добавить поддержку включения/выключения режима «Не беспокоить».

### DIFF
--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -397,6 +397,10 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
             return
 
         config, version = await self.quasar.get_device_config(self.device)
+
+        if config.get("dndMode") is None:
+            raise HomeAssistantError("Режим 'не беспокоить' не поддерживается этим устройством")
+
         config["dndMode"]["enabled"] = value
         await self.quasar.set_device_config(self.device, config, version)
 

--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -388,6 +388,18 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
 
         await self.quasar.set_device_config(self.device, config, version)
 
+    async def _set_dnd_mode(self, value: str):
+        if value == "True":
+            value = True
+        elif value == "False":
+            value = False
+        else:
+            return
+
+        config, version = await self.quasar.get_device_config(self.device)
+        config["dndMode"]["enabled"] = value
+        await self.quasar.set_device_config(self.device, config, version)
+
     async def _set_beta(self, value: str):
         if value == "True":
             value = True
@@ -810,6 +822,9 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
             return
         elif media_type == "visualization":
             await self._set_led(visualization=media_id)
+            return
+        elif media_type == "dnd_mode":
+            await self._set_dnd_mode(media_id)
             return
         elif media_type == "beta":
             await self._set_beta(media_id)


### PR DESCRIPTION
## Описание
Добавляет поддержку включения/выключения режима «Не беспокоить» на устройстве.

## Пример действия
По аналогии с существующей настройкой beta:
```yaml
service: media_player.play_media
entity_id: media_player.yandex_station_max
  data:
    media_content_id: true # допустимые значения true, или false для выключения режима
    media_content_type: dnd_mode
```

## Пример скрипта
Позволяет управлять режимом «Не беспокоить» на одном или нескольких устройствах сразу.
```yaml
script:
  yandex_station_dnd_mode:
    alias: Управление режимом «Не беспокоить» для Яндекс Станций
    description: >-
      Включение/выключение режима «Не беспокоить», детальная настройка
      режима доступна в приложении Дом с Алисой
    fields:
      devices:
        name: Устройства
        description: Выберите одно или несколько устройств
        required: true
        selector:
          device:
            entity:
              integration: yandex_station
              domain: media_player
            multiple: true
      dnd_mode_enabled:
        name: Не беспокоить
        description: >-
          Отключение звонков и уведомлений. Радионяня, таймеры,
          будильники, напоминания будут работать
        required: true
        selector:
          boolean: null
    sequence:
      - action: media_player.play_media
        target:
          device_id: "{{ devices }}"
        data:
          media:
            media_content_id: "{{ dnd_mode_enabled }}"
            media_content_type: dnd_mode
```