### PR TITLE
Fix passport auth: support new CSRF format and apply proxy in config_…

### DIFF
--- a/custom_components/yandex_station/config_flow.py
+++ b/custom_components/yandex_station/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .core.const import DOMAIN
+from .core.const import DATA_CONFIG, DOMAIN
 from .core.yandex_quasar import YandexQuasar
 from .core.yandex_session import LoginResponse, YandexSession
 
@@ -31,7 +31,13 @@ class YandexStationFlowHandler(ConfigFlow, domain=DOMAIN):
     @lru_cache()
     def yandex(self):
         session = async_create_clientsession(self.hass)
-        return YandexSession(session)
+        instance = YandexSession(session)
+        if DOMAIN in self.hass.data:
+            config = self.hass.data[DOMAIN].get(DATA_CONFIG, {})
+            instance.proxy = config.get("proxy")
+            instance.domain = config.get("domain")
+            instance.ssl = config.get("ssl")
+        return instance
 
     async def async_step_import(self, data: dict):
         """Init by component setup. Forward YAML login/pass to auth."""

--- a/custom_components/yandex_station/core/yandex_session.py
+++ b/custom_components/yandex_station/core/yandex_session.py
@@ -167,14 +167,26 @@ class YandexSession(BasicSession):
         """Listeners to handle automatic cookies update."""
         self._update_listeners.append(coro)
 
+    async def _get_csrf_token(self):
+        r = await self._get("https://passport.yandex.ru/am?app_platform=android")
+        resp = await r.text()
+        if r.status != 200 or "<title>400" in resp:
+            raise Exception(
+                f"Yandex passport returned {r.status}. "
+                f"Check proxy/VPN settings - Yandex may block requests from non-Russian IPs. "
+                f"Set proxy in YAML config: yandex_station: proxy: http://..."
+            )
+        m = re.search(r'"csrf_token" value="([^"]+)"', resp)
+        if not m:
+            m = re.search(r'window\.__CSRF__\s*=\s*"([^"]+)"', resp)
+        assert m, resp
+        return m[1]
+
     async def login_username(self, username: str) -> LoginResponse:
         """Create login session and return supported auth methods."""
         # step 1: csrf_token
-        r = await self._get("https://passport.yandex.ru/am?app_platform=android")
-        resp = await r.text()
-        m = re.search(r'"csrf_token" value="([^"]+)"', resp)
-        assert m, resp
-        self.auth_payload = {"csrf_token": m[1]}
+        csrf_token = await self._get_csrf_token()
+        self.auth_payload = {"csrf_token": csrf_token}
 
         # step 2: track_id
         r = await self._post(
@@ -220,16 +232,13 @@ class YandexSession(BasicSession):
     async def get_qr(self) -> str:
         """Get link to QR-code auth."""
         # step 1: csrf_token
-        r = await self._get("https://passport.yandex.ru/am?app_platform=android")
-        resp = await r.text()
-        m = re.search(r'"csrf_token" value="([^"]+)"', resp)
-        assert m, resp
+        csrf_token = await self._get_csrf_token()
 
         # step 2: track_id
         r = await self._post(
             "https://passport.yandex.ru/registration-validations/auth/password/submit",
             data={
-                "csrf_token": m[1],
+                "csrf_token": csrf_token,
                 "retpath": "https://passport.yandex.ru/profile",
                 "with_code": 1,
             },


### PR DESCRIPTION
…flow

- Yandex changed passport page format from <input csrf_token> to window.__CSRF__
- Added _get_csrf_token() method with fallback to new format
- Apply proxy/domain/ssl from YAML config during config_flow setup
- Add clear error message when Yandex returns 400 (proxy/VPN issue)