### PR TITLE
fix(auth): миграция get_qr на новый Passport BFF (fixes #747)

### DIFF
--- a/custom_components/yandex_station/core/yandex_session.py
+++ b/custom_components/yandex_station/core/yandex_session.py
@@ -218,32 +218,58 @@ class YandexSession(BasicSession):
         return await self.login_cookies()
 
     async def get_qr(self) -> str:
-        """Get link to QR-code auth."""
-        # step 1: csrf_token
+        """Get link to QR-code auth via the new Passport BFF.
+
+        The legacy ``/registration-validations/auth/password/submit`` endpoint
+        started returning 400/captcha for non-browser clients (see #747). The
+        new ``/pwl-yandex/api/passport/...`` BFF accepts the same inputs but
+        expects the page CSRF in the ``X-CSRF-Token`` header and explicit
+        ``Origin``/``Referer`` headers.
+        """
+        # step 1: page CSRF from /am
         r = await self._get("https://passport.yandex.ru/am?app_platform=android")
         resp = await r.text()
         m = re.search(r'"csrf_token" value="([^"]+)"', resp)
         assert m, resp
+        page_csrf = m[1]
 
-        # step 2: track_id
+        bff_headers = {
+            "X-CSRF-Token": page_csrf,
+            "Origin": "https://passport.yandex.ru",
+            "Referer": "https://passport.yandex.ru/pwl-yandex",
+        }
+
+        # step 2: start auth track
         r = await self._post(
-            "https://passport.yandex.ru/registration-validations/auth/password/submit",
-            data={
-                "csrf_token": m[1],
-                "retpath": "https://passport.yandex.ru/profile",
-                "with_code": 1,
-            },
+            "https://passport.yandex.ru/pwl-yandex/api/passport/auth/multistep_start",
+            data={},
+            headers=bff_headers,
         )
         resp = await r.json()
-        assert resp["status"] == "ok", resp
+        track_id = resp.get("track_id")
+        assert isinstance(track_id, str) and track_id, resp
+
+        # step 3: convert the track into a QR/magic-link session and receive
+        # a per-track csrf_token used by the legacy polling endpoint.
+        r = await self._post(
+            "https://passport.yandex.ru/pwl-yandex/api/passport/auth/password/submit",
+            data={
+                "track_id": track_id,
+                "with_code": 1,
+                "retpath": "https://passport.yandex.ru/profile",
+            },
+            headers=bff_headers,
+        )
+        resp = await r.json()
+        assert resp.get("status") == "ok", resp
 
         self.auth_payload = {
             "csrf_token": resp["csrf_token"],
-            "track_id": resp["track_id"],
+            "track_id": track_id,
         }
 
         return (
-            "https://passport.yandex.ru/auth/magic/code/?track_id=" + resp["track_id"]
+            "https://passport.yandex.ru/auth/magic/code/?track_id=" + track_id
         )
 
     async def login_qr(self) -> LoginResponse:


### PR DESCRIPTION
## Что делает PR

Переводит `YandexSession.get_qr` со старого эндпоинта `/registration-validations/auth/password/submit` на новый Passport  BFF `/pwl-yandex/api/passport/*`.

Закрывает #747 (и дубль #761).

## Проблема

Яндекс начал отдавать 40x вместо JSON на legacy `/registration-validations/auth/password/submit`,  Логин через куки (`mobileproxy.passport.yandex.net/1/bundle/oauth/token_by_sessionid`) не затронут и продолжает работать — именно поэтому cookie-метод сейчас единственный рабочий обход в треде.

## Решение

Фронтенд Passport уже сам переехал на новый BFF `/pwl-yandex/api/passport/*`. Этот BFF принимает те же данные, но:

1. Ждёт page CSRF в **заголовке** `X-CSRF-Token`, а не в form-поле.
2. Требует явные заголовки `Origin` / `Referer`.
3. Разбит на два вызова:
   - `POST /pwl-yandex/api/passport/auth/multistep_start` → `track_id`
   - `POST /pwl-yandex/api/passport/auth/password/submit` с `with_code=1` → per-track `csrf_token`

Legacy-эндпоинт поллинга `/auth/new/magic/status/` не менялся и всё так же использует per-track `csrf_token` из шага 3, поэтому `login_qr` не трогаем.

### Diff в двух словах

| Шаг | Было (legacy) | Стало (BFF) |
|-----|---------------|-------------|
| 1 | `GET /am?app_platform=android` → page CSRF из HTML | без изменений |
| 2 | — | `POST /pwl-yandex/api/passport/auth/multistep_start` (заголовок `X-CSRF-Token`) → `track_id` |
| 3 | `POST /registration-validations/auth/password/submit` с `csrf_token` + `retpath` + `with_code=1` в form-body → `track_id` + per-track `csrf_token` | `POST /pwl-yandex/api/passport/auth/password/submit` с заголовком `X-CSRF-Token` + `track_id`/`with_code`/`retpath` в form-body → per-track `csrf_token` |
| 4 | поллинг `/auth/new/magic/status/` | без изменений |

Cookie-логин, retry/csrf-механика в `request()` и все остальные флоу не тронуты — миграция нужна только в `get_qr`.

## Референс

Я выделил те же auth-флоу Яндекс Passport в отдельную async-библиотеку и пару дней назад отвалидировал эту BFF-миграцию против живого Passport в рамках параллельной задачи для Music Assistant:

- https://github.com/rensomail/ya-passport-auth (`flows/qr.py`)

Формат эндпоинтов/заголовков из этого PR совпадает с тем, что сейчас в этой библиотеке, и уже прогоняется реальными пользователями через QR-логин end-to-end.