### PR TITLE
Добавить поддержку датчика присутствия YNDX-00525

### DIFF
--- a/custom_components/yandex_station/binary_sensor.py
+++ b/custom_components/yandex_station/binary_sensor.py
@@ -7,9 +7,11 @@ from .core.entity import YandexCustomEntity
 from .hass import hass_utils
 
 INCLUDE_CAPABILITIES = ("devices.capabilities.lock",)
+INCLUDE_PROPERTIES = ("devices.properties.float",)
 
 ENTITY_DESCRIPTIONS = {
     "lock": BinarySensorDeviceClass.LOCK,
+    "occupancy": BinarySensorDeviceClass.OCCUPANCY,
 }
 
 
@@ -20,6 +22,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for instance in device["capabilities"]:
             if instance["type"] in INCLUDE_CAPABILITIES:
                 entities.append(YandexBinarySensor(quasar, device, instance))
+        for instance in device["properties"]:
+            if instance["type"] not in INCLUDE_PROPERTIES:
+                continue
+            if instance["parameters"]["instance"] not in ENTITY_DESCRIPTIONS:
+                continue
+            if (
+                "properties" in config
+                and instance["parameters"]["instance"] not in config["properties"]
+            ):
+                continue
+            entities.append(YandexBinarySensor(quasar, device, instance))
 
     async_add_entities(entities)
 
@@ -33,7 +46,11 @@ class YandexBinarySensor(BinarySensorEntity, YandexCustomEntity):
             self._attr_device_class = desc
 
     def internal_update(self, capabilities: dict, properties: dict):
-        if value := capabilities.get(self.instance):
-            if self.instance == "lock":
-                # On means open (unlocked), Off means closed (locked)
-                self._attr_is_on = value == "open"
+        if self.instance == "lock" and self.instance in capabilities:
+            # On means open (unlocked), Off means closed (locked)
+            self._attr_is_on = capabilities[self.instance] == "open"
+            return
+
+        if self.instance in properties:
+            value = properties[self.instance]
+            self._attr_is_on = value is not None and value > 0

--- a/custom_components/yandex_station/config_flow.py
+++ b/custom_components/yandex_station/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
+from .core import utils
 from .core.const import DOMAIN
 from .core.yandex_quasar import YandexQuasar
 from .core.yandex_session import LoginResponse, YandexSession
@@ -161,7 +162,7 @@ class OptionsFlowHandler(OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         quasar: YandexQuasar = self.hass.data[DOMAIN][self.config_entry.unique_id]
-        devices = {i["id"]: device_name(i) for i in quasar.devices}
+        devices = utils.device_names(quasar.devices)
 
         # sort by names
         devices = dict(sorted(devices.items(), key=lambda x: x[1]))
@@ -181,9 +182,3 @@ def vol_schema(schema: dict, defaults: dict | None) -> vol.Schema:
             if (value := defaults.get(key.schema)) is not None:
                 key.default = vol.default_factory(value)
     return vol.Schema(schema)
-
-
-def device_name(device: dict) -> str:
-    if room := device.get("room_name"):
-        return f"{device['house_name']} - {room} - {device['name']}"
-    return f"{device['house_name']} - {device['name']}"

--- a/custom_components/yandex_station/core/entity.py
+++ b/custom_components/yandex_station/core/entity.py
@@ -3,6 +3,7 @@ import logging
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
+from . import utils
 from .const import DOMAIN
 from .yandex_quasar import YandexQuasar
 
@@ -45,7 +46,8 @@ class YandexEntity(Entity):
 
         # "online", "unknown" or key not exist
         self._attr_available = device.get("state") != "offline"
-        self._attr_name = device["name"]
+        name = utils.device_name(device, quasar.devices)
+        self._attr_name = name
         self._attr_should_poll = False
         self._attr_unique_id = device["id"].replace("-", "")
 
@@ -53,7 +55,7 @@ class YandexEntity(Entity):
 
         self._attr_device_info: DeviceInfo = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
-            name=self.device["name"],
+            name=name,
             suggested_area=self.device.get("room_name"),
         )
 

--- a/custom_components/yandex_station/core/utils.py
+++ b/custom_components/yandex_station/core/utils.py
@@ -1,4 +1,5 @@
 import base64
+from collections import defaultdict
 import json
 import logging
 import os
@@ -44,6 +45,61 @@ HTML = (
     '<meta http-equiv="refresh" content="%s"></head>'
     "<body><pre>%s</pre></body></html>"
 )
+
+
+def device_name(device: dict, devices: list[dict] | None = None) -> str:
+    if devices and (parent := presence_parent(device, devices)):
+        return presence_zone_name(device, parent)
+    return base_device_name(device)
+
+
+def device_names(devices: list[dict]) -> dict[str, str]:
+    return {device["id"]: device_name(device, devices) for device in devices}
+
+
+def base_device_name(device: dict) -> str:
+    return device["name"]
+
+
+def presence_parent(device: dict, devices: list[dict]) -> dict | None:
+    parents = defaultdict(list)
+    for item in devices:
+        if is_presence_parent(item):
+            parents[presence_key(item)].append(item)
+
+    items = parents.get(presence_key(device), [])
+    return items[0] if len(items) == 1 else None
+
+
+def presence_key(device: dict) -> tuple | None:
+    if device.get("type") != "devices.types.sensor.presence":
+        return None
+    info = device.get("parameters", {}).get("device_info", {})
+    return (
+        device.get("house_name"),
+        device.get("room_name"),
+        info.get("model"),
+    )
+
+
+def is_presence_parent(device: dict) -> bool:
+    return presence_key(device) is not None and (
+        any(
+            prop.get("parameters", {}).get("instance") == "illumination"
+            for prop in device.get("properties", [])
+        )
+        or any(
+            cap.get("type") == "devices.capabilities.planar_view"
+            for cap in device.get("capabilities", [])
+        )
+    )
+
+
+def presence_zone_name(device: dict, parent: dict) -> str:
+    if device["id"] == parent["id"] or device["name"] == parent["name"]:
+        return base_device_name(device)
+
+    return f"{parent['name']} - {device['name']}"
 
 
 class YandexDebug(logging.Handler, HomeAssistantView):

--- a/custom_components/yandex_station/sensor.py
+++ b/custom_components/yandex_station/sensor.py
@@ -34,6 +34,7 @@ INCLUDE_TYPES = (
     "devices.types.sensor.illumination",
     "devices.types.sensor.motion",
     "devices.types.sensor.open",
+    "devices.types.sensor.presence",
     "devices.types.sensor.smoke",
     "devices.types.sensor.vibration",
     "devices.types.sensor.water_leak",
@@ -76,6 +77,7 @@ ENTITY_DESCRIPTIONS: dict[str, dict] = {
     "open": {"class": SENSOR.ENUM},
     "button": {"class": SENSOR.ENUM},
     "motion": {"class": SENSOR.ENUM},
+    "occupancy": {"units": "objects"},
     "smoke": {"class": SENSOR.ENUM},
     "gas": {"class": SENSOR.ENUM},
     "food_level": {"class": SENSOR.ENUM},
@@ -114,7 +116,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class YandexCustomSensor(SensorEntity, YandexCustomEntity):
     def internal_init(self, capabilities: dict, properties: dict):
         if desc := ENTITY_DESCRIPTIONS.get(self.instance):
-            self._attr_device_class = desc["class"]
+            if "class" in desc:
+                self._attr_device_class = desc["class"]
             if "units" in desc:
                 self._attr_native_unit_of_measurement = desc["units"]
                 self._attr_state_class = SensorStateClass.MEASUREMENT

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,102 @@
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from custom_components.yandex_station.binary_sensor import YandexBinarySensor
+from . import FakeQuasar, true, update_ha_state
+
+
+def test_yndx_00525_presence_sensor():
+    device = {
+        "id": "xxx",
+        "name": "Датчик присутствия",
+        "type": "devices.types.sensor.presence",
+        "icon_url": "https://avatars.mds.yandex.net/get-iot/icons-devices-devices.types.sensor.svg/orig",
+        "capabilities": [],
+        "properties": [
+            {
+                "type": "devices.properties.float",
+                "retrievable": true,
+                "reportable": true,
+                "parameters": {
+                    "instance": "occupancy",
+                    "name": "количество объектов",
+                    "unit": "unit.object_quantity",
+                },
+                "state": {
+                    "percent": None,
+                    "status": None,
+                    "value": 1,
+                },
+                "state_changed_at": "2026-06-27T09:55:04Z",
+                "last_updated": "2026-06-27T09:55:04Z",
+            }
+        ],
+        "item_type": "device",
+        "skill_id": "xxx",
+        "room_name": "Кабинет",
+        "state": "online",
+        "created": "2026-06-27T09:55:04Z",
+        "parameters": {
+            "device_info": {
+                "manufacturer": "Yandex",
+                "model": "YNDX-00525",
+            }
+        },
+    }
+
+    state = update_ha_state(
+        YandexBinarySensor, device, config=device["properties"][0]
+    )
+    assert state.state == "on"
+    assert state.attributes == {
+        "device_class": BinarySensorDeviceClass.OCCUPANCY,
+        "friendly_name": "Датчик присутствия количество объектов",
+    }
+
+
+def test_yndx_00525_zone_entity_name():
+    parent = {
+        "id": "sensor",
+        "name": "Датчик присутствия",
+        "house_name": "Мой дом",
+        "room_name": "Гостиная",
+        "type": "devices.types.sensor.presence",
+        "capabilities": [
+            {"type": "devices.capabilities.planar_view", "retrievable": true}
+        ],
+        "properties": [
+            {"parameters": {"instance": "illumination"}},
+            {"parameters": {"instance": "occupancy"}},
+        ],
+        "parameters": {"device_info": {"model": "YNDX-00525"}},
+    }
+    zone = {
+        "id": "zone",
+        "name": "Диван",
+        "house_name": "Мой дом",
+        "room_name": "Гостиная",
+        "type": "devices.types.sensor.presence",
+        "capabilities": [
+            {"type": "devices.capabilities.presence_zone", "retrievable": true}
+        ],
+        "properties": [
+            {
+                "type": "devices.properties.float",
+                "retrievable": true,
+                "parameters": {
+                    "instance": "occupancy",
+                    "name": "присутствие",
+                    "unit": "unit.object_quantity",
+                },
+                "state": {"value": 1},
+            }
+        ],
+        "parameters": {"device_info": {"model": "YNDX-00525"}},
+    }
+
+    quasar = FakeQuasar(zone)
+    quasar.devices = [parent, zone]
+    entity = YandexBinarySensor(quasar, zone, zone["properties"][0])
+    assert (
+        entity.name
+        == "Датчик присутствия - Диван присутствие"
+    )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -47,3 +47,50 @@ def test_fix_dialog_text():
     src = '<speaker effect="megaphone">Ехал Грека через реку <speaker effect="-">видит Грека в реке рак'
     dst = '<speaker effect="megaphone">ЕХАЛ ГРЕКА ЧЕРЕЗ РЕКУ <speaker effect="-">ВИДИТ ГРЕКА В РЕКЕ РАК'
     assert utils.fix_dialog_text(src) == dst
+
+
+def test_presence_zone_device_names():
+    devices = [
+        {
+            "id": "sensor",
+            "name": "Датчик присутствия",
+            "house_name": "Мой дом",
+            "room_name": "Гостиная",
+            "type": "devices.types.sensor.presence",
+            "capabilities": [
+                {"type": "devices.capabilities.planar_view"},
+            ],
+            "properties": [
+                {"parameters": {"instance": "illumination"}},
+                {"parameters": {"instance": "occupancy"}},
+            ],
+            "parameters": {"device_info": {"model": "YNDX-00525"}},
+        },
+        {
+            "id": "zone",
+            "name": "Диван",
+            "house_name": "Мой дом",
+            "room_name": "Гостиная",
+            "type": "devices.types.sensor.presence",
+            "capabilities": [
+                {"type": "devices.capabilities.presence_zone"},
+            ],
+            "properties": [
+                {"parameters": {"instance": "occupancy"}},
+            ],
+            "parameters": {"device_info": {"model": "YNDX-00525"}},
+        },
+        {
+            "id": "light",
+            "name": "Люстра",
+            "house_name": "Мой дом",
+            "room_name": "Гостиная",
+            "type": "devices.types.light",
+        },
+    ]
+
+    assert utils.device_names(devices) == {
+        "sensor": "Датчик присутствия",
+        "zone": "Датчик присутствия - Диван",
+        "light": "Люстра",
+    }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -232,6 +232,69 @@ def test_sensor_qingping():
     }
 
 
+def test_yndx_00525_occupancy_sensor():
+    device = {
+        "id": "xxx",
+        "name": "Датчик присутствия",
+        "type": "devices.types.sensor.presence",
+        "icon_url": "https://avatars.mds.yandex.net/get-iot/icons-devices-devices.types.sensor.svg/orig",
+        "capabilities": [
+            {
+                "type": "devices.capabilities.presence_zone",
+                "retrievable": true,
+                "reportable": true,
+                "parameters": {
+                    "max_occupancy_zones_count": 1,
+                    "max_noise_zones_count": 0,
+                },
+                "state": {
+                    "zones": [
+                        {
+                            "id": 0,
+                            "enabled": true,
+                            "mutable": true,
+                            "type": "presence.zones.types.occupancy",
+                            "shape": {"type": "presence.zone_shapes.types.grid"},
+                        }
+                    ]
+                },
+            }
+        ],
+        "properties": [
+            {
+                "type": "devices.properties.float",
+                "retrievable": false,
+                "reportable": true,
+                "parameters": {
+                    "instance": "occupancy",
+                    "name": "присутствие",
+                    "unit": "unit.object_quantity",
+                    "range": {"min": 0, "max": 3, "precision": 1},
+                },
+                "state": {"percent": null, "status": null, "value": 2},
+            }
+        ],
+        "item_type": "device",
+        "skill_id": "xxx",
+        "room_name": "Кабинет",
+        "state": "online",
+        "parameters": {
+            "device_info": {
+                "manufacturer": "Yandex",
+                "model": "YNDX-00525",
+            }
+        },
+    }
+
+    state = update_ha_state(YandexCustomSensor, device, config=device["properties"][0])
+    assert state.state == "2"
+    assert state.attributes == {
+        "friendly_name": "Датчик присутствия присутствие",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit_of_measurement": "objects",
+    }
+
+
 def test_sensor_yandex():
     device = {
         "id": "xxx",


### PR DESCRIPTION
Добавлена поддержка датчика присутствия Яндекса `YNDX-00525`.

Что сделано:

- добавлен тип `devices.types.sensor.presence`;
- добавлена обработка `occupancy`:
  - как `binary_sensor` с `device_class: occupancy`;
  - как обычный `sensor` с числовым количеством объектов;
- поддержаны виртуальные устройства зон присутствия, которые Яндекс отдаёт отдельно от основного датчика;
- для дочерних зон добавлено уточняющее имя вида `Датчик присутствия - Диван`;
- обычные несоставные устройства не переименовываются и продолжают использовать имя, которое отдаёт Яндекс;
- добавлены тесты для:
  - `binary_sensor` присутствия;
  - числового `occupancy` sensor;
  - формирования имени зоны.

Особенности именования:

Яндекс отдаёт зоны присутствия как отдельные виртуальные устройства. При этом имя зоны само по себе может быть недостаточно информативным, например `Диван`.

Чтобы в списке устройств и в HA entities было понятно, к какому датчику относится зона, для дочерних зон формируется имя:

`<имя основного датчика> - <имя зоны>`

Например:

`Датчик присутствия - Диван`

Это применяется только к дочерним зонам presence-датчика. Обычные устройства не затрагиваются: `Люстра` остаётся `Люстра`, `Датчик присутствия` остаётся `Датчик присутствия`.

По наблюдениям из diagnostics/websocket updates:

- основной датчик отдаёт `illumination` и общий `occupancy`;
- зоны приходят как отдельные виртуальные устройства `devices.types.sensor.presence` с собственным `occupancy`;
- значение `occupancy > 0` означает наличие объекта/человека.

Проверка:

- вручную проверено на живой инсталляции Home Assistant с реальным `YNDX-00525`;
- локально проверен синтаксис изменённых Python-файлов через `ast.parse`;
- `pytest` локально не запускался, так как в окружении нет установленного `pytest`/зависимостей Home Assistant.