### PR TITLE
Add basic YNDX-00525 presence support

### DIFF
--- a/custom_components/yandex_station/binary_sensor.py
+++ b/custom_components/yandex_station/binary_sensor.py
@@ -7,9 +7,11 @@ from .core.entity import YandexCustomEntity
 from .hass import hass_utils
 
 INCLUDE_CAPABILITIES = ("devices.capabilities.lock",)
+INCLUDE_PROPERTIES = ("devices.properties.float",)
 
 ENTITY_DESCRIPTIONS = {
     "lock": BinarySensorDeviceClass.LOCK,
+    "occupancy": BinarySensorDeviceClass.OCCUPANCY,
 }
 
 
@@ -20,6 +22,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for instance in device["capabilities"]:
             if instance["type"] in INCLUDE_CAPABILITIES:
                 entities.append(YandexBinarySensor(quasar, device, instance))
+        for instance in device["properties"]:
+            if instance["type"] not in INCLUDE_PROPERTIES:
+                continue
+            if instance["parameters"]["instance"] not in ENTITY_DESCRIPTIONS:
+                continue
+            if (
+                "properties" in config
+                and instance["parameters"]["instance"] not in config["properties"]
+            ):
+                continue
+            entities.append(YandexBinarySensor(quasar, device, instance))
 
     async_add_entities(entities)
 
@@ -33,7 +46,11 @@ class YandexBinarySensor(BinarySensorEntity, YandexCustomEntity):
             self._attr_device_class = desc
 
     def internal_update(self, capabilities: dict, properties: dict):
-        if value := capabilities.get(self.instance):
-            if self.instance == "lock":
-                # On means open (unlocked), Off means closed (locked)
-                self._attr_is_on = value == "open"
+        if self.instance == "lock" and self.instance in capabilities:
+            # On means open (unlocked), Off means closed (locked)
+            self._attr_is_on = capabilities[self.instance] == "open"
+            return
+
+        if self.instance in properties:
+            value = properties[self.instance]
+            self._attr_is_on = value is not None and value > 0

--- a/custom_components/yandex_station/sensor.py
+++ b/custom_components/yandex_station/sensor.py
@@ -34,6 +34,7 @@ INCLUDE_TYPES = (
     "devices.types.sensor.illumination",
     "devices.types.sensor.motion",
     "devices.types.sensor.open",
+    "devices.types.sensor.presence",
     "devices.types.sensor.smoke",
     "devices.types.sensor.vibration",
     "devices.types.sensor.water_leak",
@@ -76,6 +77,7 @@ ENTITY_DESCRIPTIONS: dict[str, dict] = {
     "open": {"class": SENSOR.ENUM},
     "button": {"class": SENSOR.ENUM},
     "motion": {"class": SENSOR.ENUM},
+    "occupancy": {"units": "objects"},
     "smoke": {"class": SENSOR.ENUM},
     "gas": {"class": SENSOR.ENUM},
     "food_level": {"class": SENSOR.ENUM},
@@ -114,7 +116,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class YandexCustomSensor(SensorEntity, YandexCustomEntity):
     def internal_init(self, capabilities: dict, properties: dict):
         if desc := ENTITY_DESCRIPTIONS.get(self.instance):
-            self._attr_device_class = desc["class"]
+            if "class" in desc:
+                self._attr_device_class = desc["class"]
             if "units" in desc:
                 self._attr_native_unit_of_measurement = desc["units"]
                 self._attr_state_class = SensorStateClass.MEASUREMENT


### PR DESCRIPTION
Добавлена базовая поддержка датчика присутствия Яндекса `YNDX-00525`.

Что сделано:

- добавлен тип `devices.types.sensor.presence`;
- добавлена обработка float property `occupancy` (`unit.object_quantity`);
- `occupancy` добавлен как `binary_sensor` с `device_class: occupancy`;
- `occupancy` также доступен как обычный `sensor` с числовым количеством объектов.

По наблюдениям на реальном устройстве значение `occupancy > 0` означает наличие объекта/человека.

Проверка:

- вручную проверено на живой инсталляции Home Assistant с реальным `YNDX-00525`;
- локально проверен синтаксис изменённых Python-файлов через `py_compile`;