### PR TITLE
Add fan platform support (devices.types.ventilation.fan)

### DIFF
--- a/custom_components/yandex_station/__init__.py
+++ b/custom_components/yandex_station/__init__.py
@@ -57,6 +57,7 @@ PLATFORMS = [
     "camera",
     "climate",
     "cover",
+    "fan",
     "humidifier",
     "light",
     "media_player",

--- a/custom_components/yandex_station/core/yandex_quasar.py
+++ b/custom_components/yandex_station/core/yandex_quasar.py
@@ -28,6 +28,9 @@ IOT_TYPES = {
     "humidity": "devices.capabilities.range",
     "ionization": "devices.capabilities.toggle",
     "backlight": "devices.capabilities.toggle",
+    # fan
+    "oscillation": "devices.capabilities.toggle",
+    "controls_locked": "devices.capabilities.toggle",
     # climate
     "swing": "devices.capabilities.mode",
     # kettle:

--- a/custom_components/yandex_station/fan.py
+++ b/custom_components/yandex_station/fan.py
@@ -1,0 +1,95 @@
+import logging
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .core.entity import YandexEntity
+from .hass import hass_utils
+
+_LOGGER = logging.getLogger(__name__)
+
+INCLUDE_TYPES = ("devices.types.ventilation.fan",)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    async_add_entities(
+        YandexFan(quasar, device, config)
+        for quasar, device, config in hass_utils.incluce_devices(hass, entry)
+        if device["type"] in INCLUDE_TYPES
+    )
+
+
+# noinspection PyAbstractClass
+class YandexFan(FanEntity, YandexEntity):
+    speeds: list[str] = []
+
+    # https://developers.home-assistant.io/blog/2024/07/23/fan-fanentityfeatures-expanded
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
+        _enable_turn_on_off_backwards_compatibility = False
+
+    def internal_init(self, capabilities: dict, properties: dict):
+        features = FanEntityFeature(0)
+
+        if "on" in capabilities and (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
+            features |= FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+
+        if item := capabilities.get("fan_speed"):
+            # keep speeds in the order the device reports them
+            self.speeds = [i["value"] for i in item["modes"]]
+            features |= FanEntityFeature.SET_SPEED
+
+        if "oscillation" in capabilities:
+            features |= FanEntityFeature.OSCILLATE
+
+        self._attr_supported_features = features
+
+    def internal_update(self, capabilities: dict, properties: dict):
+        if "on" in capabilities:
+            self._attr_is_on = capabilities["on"]
+
+        if "fan_speed" in capabilities and self.speeds:
+            value = capabilities["fan_speed"]
+            self._attr_percentage = (
+                ordered_list_item_to_percentage(self.speeds, value)
+                if value in self.speeds
+                else None
+            )
+
+        # report 0% while off, so the speed slider doesn't stick
+        # at the last speed on a turned off fan
+        if self._attr_is_on is False:
+            self._attr_percentage = 0
+
+        if "oscillation" in capabilities:
+            self._attr_oscillating = capabilities["oscillation"]
+
+    @property
+    def speed_count(self) -> int:
+        return len(self.speeds) or 1
+
+    async def async_set_percentage(self, percentage: int):
+        if percentage == 0:
+            await self.device_action("on", False)
+            return
+        # sending fan_speed to a turned off device doesn't power it on
+        if not self._attr_is_on:
+            await self.device_action("on", True)
+        mode = percentage_to_ordered_list_item(self.speeds, percentage)
+        await self.device_action("fan_speed", mode)
+
+    async def async_oscillate(self, oscillating: bool):
+        await self.device_action("oscillation", oscillating)
+
+    async def async_turn_on(
+        self, percentage: int = None, preset_mode: str = None, **kwargs
+    ):
+        await self.device_action("on", True)
+        if percentage is not None and self.speeds:
+            await self.async_set_percentage(percentage)
+
+    async def async_turn_off(self, **kwargs):
+        await self.device_action("on", False)

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,102 @@
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+
+from custom_components.yandex_station.fan import YandexFan
+from . import false, true, update_ha_state
+
+
+def fan_device(on: bool, speed: str, oscillation: bool) -> dict:
+    return {
+        "id": "xxx",
+        "name": "Mijia Smart Tower Fan 2",
+        "type": "devices.types.ventilation.fan",
+        "icon_url": "https://avatars.mds.yandex.net/get-iot/icons-devices-devices.types.fan.svg/orig",
+        "capabilities": [
+            {
+                "reportable": true,
+                "retrievable": true,
+                "type": "devices.capabilities.on_off",
+                "state": {"instance": "on", "value": on},
+                "parameters": {"split": false},
+                "can_be_deferred": true,
+            },
+            {
+                "reportable": true,
+                "retrievable": true,
+                "type": "devices.capabilities.mode",
+                "state": {"instance": "fan_speed", "value": speed},
+                "parameters": {
+                    "instance": "fan_speed",
+                    "name": "скорость вентиляции",
+                    "modes": [
+                        {"value": "low", "name": "Низкая"},
+                        {"value": "medium", "name": "Средняя"},
+                        {"value": "high", "name": "Высокая"},
+                        {"value": "turbo", "name": "Турбо"},
+                    ],
+                },
+            },
+            {
+                "reportable": true,
+                "retrievable": true,
+                "type": "devices.capabilities.toggle",
+                "state": {"instance": "controls_locked", "value": false},
+                "parameters": {
+                    "instance": "controls_locked",
+                    "name": "блокировка управления",
+                },
+            },
+            {
+                "reportable": true,
+                "retrievable": true,
+                "type": "devices.capabilities.toggle",
+                "state": {"instance": "oscillation", "value": oscillation},
+                "parameters": {"instance": "oscillation", "name": "вращение"},
+            },
+        ],
+        "properties": [],
+        "item_type": "device",
+        "skill_id": "ad26f8c2-fc31-4928-a653-d829fda7e6c2",
+        "room_name": "Спальня",
+        "state": "online",
+        "parameters": {
+            "device_info": {
+                "manufacturer": "dmaker",
+                "model": "dmaker.fan.p45",
+                "sw_version": "1.1.1.0007",
+            }
+        },
+    }
+
+
+def expected_features() -> FanEntityFeature:
+    features = FanEntityFeature.SET_SPEED | FanEntityFeature.OSCILLATE
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
+        features |= FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+    return features
+
+
+def test_fan_on():
+    device = fan_device(on=true, speed="low", oscillation=true)
+
+    state = update_ha_state(YandexFan, device, config={})
+    assert state.state == "on"
+    assert state.attributes == {
+        "friendly_name": "Mijia Smart Tower Fan 2",
+        "oscillating": True,
+        "percentage": 25,
+        "percentage_step": 25.0,
+        "preset_mode": None,
+        "preset_modes": None,
+        "supported_features": expected_features(),
+    }
+
+
+def test_fan_off():
+    device = fan_device(on=false, speed="high", oscillation=false)
+
+    state = update_ha_state(YandexFan, device, config={})
+    assert state.state == "off"
+    # a turned off fan reports 0%, not the last speed
+    assert state.attributes["percentage"] == 0
+    assert state.attributes["oscillating"] is False


### PR DESCRIPTION
Adds a fan platform for Yandex smart home fans:

- on/off, speed control (device modes mapped to percentage), oscillation
- sending fan_speed to a powered-off device doesn't turn it on, so the
  platform sends "on" first when the speed slider is used on a turned off fan
- a turned off fan reports 0% so the speed slider doesn't stick at the
  last speed
- FanEntityFeature.TURN_ON / TURN_OFF are gated on HA >= 2024.8
  (same pattern as climate.py), min supported HA stays 2023.2
- oscillation and controls_locked added to IOT_TYPES
- unit tests with a real device payload (dmaker.fan.p45 /
  Mijia Smart Tower Fan 2)

Tested live with Mijia Smart Tower Fan 2 via Yandex cloud.
