### PR TITLE
Fix playing media URLs on new station firmware (#797, #800)

### DIFF
--- a/custom_components/yandex_station/core/utils.py
+++ b/custom_components/yandex_station/core/utils.py
@@ -199,7 +199,9 @@ RE_MEDIA = {
 }
 
 
-async def get_media_payload(session: YandexSession, media_id: str) -> dict | None:
+async def get_media_payload(
+    session: YandexSession, media_id: str, audio_client: bool = False
+) -> dict | None:
     for k, v in RE_MEDIA.items():
         if m := v.search(media_id):
             if k in ("youtube", "kinopoisk", "strm", "yavideo"):
@@ -252,13 +254,48 @@ async def get_media_payload(session: YandexSession, media_id: str) -> dict | Non
                     return None
 
     if ext := await stream.get_content_type(session._session, media_id):
-        return get_stream_url(media_id, "stream." + ext)
+        return get_stream_url(media_id, "stream." + ext, audio_client=audio_client)
 
     return None
 
 
+def audio_play_command(url: str, ext: str, metadata: dict = None) -> dict:
+    """Play any URL via the `audio_play` directive - the same one Yandex cloud
+    uses for music. Station firmware since ~July 2026 ignores the payload of the
+    legacy `radio_play` directive and falls back to a random Yandex radio.
+
+    Station detects the codec from the content, so `format` only has to be a
+    valid enum value: HLS for playlists and MP3 for everything else (verified
+    with real aac/flac/wav files). An unknown value makes the station drop the
+    directive without a single request to the URL.
+    """
+    hls = ext == "m3u8"
+    payload = {
+        "stream": {
+            "url": url,
+            "format": "HLS" if hls else "MP3",
+            # `Track` gives a progress bar and artist, `FmRadio` - a radio UI
+            "type": "FmRadio" if hls else "Track",
+            "offset_ms": 0,
+        },
+        "set_pause": False,
+    }
+    if metadata:
+        media = {}
+        if title := metadata.get("title"):
+            media["title"] = title
+        if subtitle := metadata.get("subtitle"):
+            media["subtitle"] = subtitle
+        # station reports it back as `coverURI`, which is always schemeless
+        if (image := metadata.get("imageUrl")) and image.startswith("https://"):
+            media["art_image_url"] = image[8:]
+        if media:
+            payload["metadata"] = media
+    return external_command("audio_play", payload)
+
+
 def get_stream_url(
-    media_id: str, media_type: str, metadata: dict = None
+    media_id: str, media_type: str, metadata: dict = None, audio_client: bool = False
 ) -> dict | None:
     if media_type.startswith("stream."):
         ext = media_type[7:]  # manual file extension
@@ -267,8 +304,13 @@ def get_stream_url(
 
     if ext in ("aac", "flac", "m3u8", "mp3", "mp4", "wav"):
         # station can't handle links without extension
+        stream_url = stream.get_url(media_id, ext, 3)
+
+        if audio_client:
+            return audio_play_command(stream_url, ext, metadata)
+
         payload = {
-            "streamUrl": stream.get_url(media_id, ext, 3),
+            "streamUrl": stream_url,
             "force_restart_player": True,
         }
         if metadata:

--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -173,6 +173,10 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
     # true of false if device has HDMI
     hdmi_audio: Optional[bool] = None
 
+    # station supports the `audio_play` directive (reported in every local
+    # message), used to play media URLs instead of the legacy `radio_play`
+    audio_client: bool = False
+
     is_on: bool = None
     """Yandex TV screen state. None if device don't have this state."""
 
@@ -548,6 +552,9 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
             self.async_write_ha_state()
             return
 
+        if features := data.get("supported_features"):
+            self.audio_client = "audio_client" in features
+
         state = data["state"]
         state.pop("timeSinceLastVoiceActivity", None)
 
@@ -878,16 +885,19 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
                 )
                 # we use the sourced_media.url to reduce the link size
                 payload = utils.get_stream_url(
-                    sourced_media.url, media_type, extra.get("metadata")
+                    sourced_media.url,
+                    media_type,
+                    extra.get("metadata"),
+                    self.audio_client,
                 )
 
             elif "https://" in media_id or "http://" in media_id:
                 payload = utils.get_stream_url(
-                    media_id, media_type, extra.get("metadata")
+                    media_id, media_type, extra.get("metadata"), self.audio_client
                 )
                 if not payload:
                     payload = await utils.get_media_payload(
-                        self.quasar.session, media_id
+                        self.quasar.session, media_id, self.audio_client
                     )
 
             elif media_type.startswith(("text:", "dialog:")):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,105 @@
+import base64
+import json
+
+from custom_components.yandex_station.core import stream, utils
+
+from . import FakeYandexStation
+
+STREAM_URL = "http://192.168.1.123:8123/test.mp3"
+
+
+def decode(payload: dict) -> tuple[str, dict]:
+    """externalCommandBypass => (directive name, directive payload)."""
+    assert payload["command"] == "externalCommandBypass"
+
+    raw = base64.b64decode(payload["data"])
+    fields, pos = {}, 0
+    while pos < len(raw):
+        tag, wire = raw[pos] >> 3, raw[pos] & 0b111
+        assert wire == 2, wire  # both fields are LEN-delimited strings
+        pos += 1
+
+        size = shift = 0
+        while True:
+            byte = raw[pos]
+            pos += 1
+            size |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                break
+            shift += 7
+
+        fields[tag] = raw[pos : pos + size].decode()
+        pos += size
+
+    return fields[1], json.loads(fields[2])
+
+
+def setup_module():
+    # get_stream_url wraps every link in the HA proxy view
+    stream.StreamView.hass_url = "http://192.168.1.123:8123"
+    stream.StreamView.key = "test"
+
+
+def test_radio_play():
+    """Legacy directive for stations without the audio client."""
+    payload = utils.get_stream_url(STREAM_URL, "music")
+    name, data = decode(payload)
+
+    assert name == "radio_play"
+    assert data["force_restart_player"] is True
+    assert ".mp3" in data["streamUrl"]
+
+
+def test_audio_play():
+    """Station firmware since ~2026.07 ignores radio_play params."""
+    payload = utils.get_stream_url(STREAM_URL, "music", audio_client=True)
+    name, data = decode(payload)
+
+    assert name == "audio_play"
+    # format is required - without it the station drops the directive
+    assert data["stream"]["format"] == "MP3"
+    assert data["stream"]["type"] == "Track"
+    assert data["stream"]["offset_ms"] == 0
+    assert ".mp3" in data["stream"]["url"]
+    assert data["set_pause"] is False
+    assert "metadata" not in data
+
+
+def test_audio_play_hls():
+    payload = utils.get_stream_url(
+        "http://192.168.1.123:8123/playlist.m3u8", "music", audio_client=True
+    )
+    name, data = decode(payload)
+
+    assert name == "audio_play"
+    assert data["stream"]["format"] == "HLS"
+    assert data["stream"]["type"] == "FmRadio"
+
+
+def test_audio_play_metadata():
+    metadata = {
+        "title": "Title",
+        "subtitle": "Artist",
+        "imageUrl": "https://avatars.mds.yandex.net/cover/%%",
+    }
+    payload = utils.get_stream_url(STREAM_URL, "music", metadata, audio_client=True)
+    name, data = decode(payload)
+
+    assert data["metadata"]["title"] == "Title"
+    assert data["metadata"]["subtitle"] == "Artist"
+    # station returns it back as a schemeless coverURI
+    assert data["metadata"]["art_image_url"] == "avatars.mds.yandex.net/cover/%%"
+
+
+def test_audio_client_support():
+    """Stations report supported features in every local message."""
+    entity = FakeYandexStation()
+    assert entity.audio_client is False
+
+    entity.async_set_state(
+        {
+            "state": {"aliceState": "IDLE", "playing": False, "volume": 0.2},
+            "supported_features": ["audio_client", "audio_client_hls", "multiroom"],
+        }
+    )
+    assert entity.audio_client is True


### PR DESCRIPTION
Fixes #797, fixes #800.

## Проблема

Прошивки станций, собранные примерно с 17.07.2026, **игнорируют параметры директивы `radio_play`**: станция не делает ни одного запроса к `streamUrl` и вместо него включает случайную Яндекс.Радиостанцию. Ломается всё, что играет ссылки: `media_player.play_media`, Browse Media, Music Assistant. В issues это подтвердили для Мини 2, Мини 3, Лайт, Миди и Станции 2.

## Решение

Играть ссылки через директиву **`audio_play`** — ту самую, которую станции отправляет само облако Яндекса при воспроизведении музыки. Её payload я снял из `vinsResponse` голосового запроса «включи радио джаз» на живой станции:

```json
{
  "stream": {"url": "https://...playlist.m3u8", "format": "HLS", "type": "FmRadio", "offset_ms": 0},
  "metadata": {"title": "Радио JAZZ", "art_image_url": "avatars.mds.yandex.net/...", "subtitle": ""},
  "set_pause": false
}
```

Станции сообщают о поддержке этой директивы как `audio_client` в `supported_features` — это поле приходит в **каждом** сообщении локального протокола, поэтому используется как feature gate. Если его нет — остаётся старый `radio_play`, так что для непрошитых устройств поведение не меняется.

## Что проверено на живой станции

Станция Миди (2023), прошивка `0.359.1.3.4389602532.20260717.150`, интеграция 3.21.4:

| Проверка | Результат |
|---|---|
| `radio_play` со `streamUrl` (как сейчас) | ❌ нет ни одного HTTP-запроса от станции, играет «Открытие» |
| `audio_play` с тем же URL | ✅ станция скачивает файл и играет его |
| `media_player.play_media` с локальным mp3 | ✅ играет, `media_position` идёт |
| Music Assistant → станция (трек из Jellyfin) | ✅ играет |
| HLS (m3u8) | ✅ играет с `format: HLS` |
| aac / flac / wav, отданные как `format: MP3` | ✅ играют, длительность определяется верно |
| `stream.format` отсутствует или неизвестен | ❌ директива молча отбрасывается, запроса к URL нет |
| Смена URL без `stop` | ✅ переключается |
| `title` / `subtitle` / `art_image_url` | ✅ возвращаются в `playerState` |

Отсюда два неочевидных момента, которые учтены в коде:

1. **`format` обязателен.** Без него (или с произвольным значением) станция не делает запрос вообще.
2. **Кодек определяется по содержимому**, а не по `format`: файлы aac/flac/wav спокойно играют как `MP3`. Поэтому маппинг простой — `HLS` для m3u8 и `MP3` для остального, и весь список поддерживаемых расширений сохраняется.

`art_image_url` передаётся без схемы, потому что станция возвращает его в `coverURI`, к которому интеграция сама приписывает `https://`.

## Тесты

Добавлен `tests/test_stream.py` — декодирует `externalCommandBypass` обратно в protobuf и проверяет обе директивы, HLS-ветку, метаданные и feature gate. Весь набор: 58 passed.

## Чего не делает этот PR

Не трогает `playMusic` (Яндекс.Музыка по id) и TTS — они ходят другими командами и не сломались.

Замечание для тестирования на других моделях: `audio_play` не проверялся на **старых** прошивках (у меня нет устройства с прошивкой до июля). Feature gate по `audio_client` должен оставить их на прежнем пути, но если у кого-то из репортеров [#797](https://github.com/AlexxIT/YandexStation/issues/797) / [#800](https://github.com/AlexxIT/YandexStation/issues/800) есть непрошитая станция — стоит протестировать.
