### PR TITLE
Enable lock platform for cars and fix lock action type (HTTP 400)

### DIFF
--- a/custom_components/yandex_station/__init__.py
+++ b/custom_components/yandex_station/__init__.py
@@ -59,6 +59,7 @@ PLATFORMS = [
     "cover",
     "humidifier",
     "light",
+    "lock",
     "media_player",
     "number",
     "remote",

--- a/custom_components/yandex_station/core/yandex_quasar.py
+++ b/custom_components/yandex_station/core/yandex_quasar.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 IOT_TYPES = {
     "on": "devices.capabilities.on_off",
+    "lock": "devices.capabilities.lock",
     "temperature": "devices.capabilities.range",
     "fan_speed": "devices.capabilities.mode",
     "thermostat": "devices.capabilities.mode",


### PR DESCRIPTION
### Problem

For a car device (`devices.types.remote_car`, tested on a GWM Tank 300) the door locks arrive from Yandex as a `devices.capabilities.lock` capability, but no controllable `lock` entity is created — only a read-only `binary_sensor`.

Two root causes:

1. **`lock` platform is never loaded.** `lock.py` (`YandexLock`) already exists but `"lock"` is missing from `PLATFORMS` in `__init__.py`, so its `async_setup_entry` is never called.

2. **`lock`/`unlock` returns HTTP 400.** `device_action("lock", …)` resolves the capability type via `IOT_TYPES.get(instance, "devices.capabilities.custom.button")`, and `IOT_TYPES` has no `"lock"` key — so the request is sent with the wrong type `devices.capabilities.custom.button` and the Yandex IoT API rejects it.

### Fix

- add `"lock"` to `PLATFORMS` (`__init__.py`)
- add `"lock": "devices.capabilities.lock"` to `IOT_TYPES` (`core/yandex_quasar.py`)

The `closed`/`open` values already used by `lock.py` match the capability's `parameters.values`, so no change there.

### Testing

On a `devices.types.remote_car` (GWM Tank 300): after the change a `lock.*` entity appears and unlock (setting value `open`) is accepted by the API. Note this particular car only advertises `capabilities.lock.operations.set_open`, so remote lock may be unsupported on the vehicle side — but that is a per-device limitation, not this integration.


Fixes #807
