### PR TITLE
Fix next/prev, voice takeover and pause/resume for locally-pushed media (follow-up to #802)

### DIFF
--- a/custom_components/yandex_station/core/stream.py
+++ b/custom_components/yandex_station/core/stream.py
@@ -79,7 +79,14 @@ CONTENT_TYPES = {
 
 REQUEST_HEADERS = (hdrs.RANGE,)
 RESPONSE_HEADERS = (hdrs.ACCEPT_RANGES, hdrs.CONTENT_LENGTH, hdrs.CONTENT_RANGE)
-STREAM_TIMEOUT = ClientTimeout(sock_connect=10, sock_read=10)
+# no sock_read cap: a paced/live upstream (e.g. Music Assistant's flow stream,
+# which deliberately throttles delivery close to real-time) can legitimately
+# go quiet between chunks for longer than any short read timeout would allow.
+# A 10s cap here made the proxy drop the connection mid-track, forcing the
+# station to reconnect and the upstream to restart its stream from scratch -
+# which, for Music Assistant, resets its own current-track bookkeeping and
+# made "next" jump to the wrong track after a few natural track changes.
+STREAM_TIMEOUT = ClientTimeout(sock_connect=10, sock_read=None)
 
 
 async def get_content_type(session: ClientSession, url: str) -> str | None:

--- a/custom_components/yandex_station/core/yandex_station.py
+++ b/custom_components/yandex_station/core/yandex_station.py
@@ -44,7 +44,6 @@ _LOGGER = logging.getLogger(__name__)
 
 RE_MUSIC_ID = re.compile(r"^\d+(:\d+)?$")
 
-
 BASE_FEATURES = (
     MediaPlayerEntityFeature.TURN_OFF
     | MediaPlayerEntityFeature.VOLUME_SET
@@ -176,6 +175,41 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
     # station supports the `audio_play` directive (reported in every local
     # message), used to play media URLs instead of the legacy `radio_play`
     audio_client: bool = False
+
+    # media_id we last pushed via audio_play/radio_play (not a real Yandex
+    # Music track). While it's playing we report it back as media_content_id
+    # instead of the station's own player_state id, so orchestrators like
+    # Music Assistant can recognize their stream by URL match and keep
+    # routing next/prev through their own queue instead of falling back to
+    # the raw glagol "next"/"prev", which the station resolves against its
+    # own Yandex Music context, not our pushed URL.
+    _pushed_media_id: Optional[str] = None
+    # title we asked the station to display for that push (via metadata) -
+    # the station keeps reporting hasNext/playerState after a voice/app
+    # takeover (Алиса, играй ...), with no IDLE gap to tell us our push
+    # ended. If the reported title no longer matches what we sent, someone
+    # else took over playback, so _pushed_media_id must stop being trusted.
+    _pushed_media_title: Optional[str] = None
+    # whether the station has actually echoed _pushed_media_title at least
+    # once since the push. Right after we push, the station may still be
+    # reporting the previous (e.g. voice-started) track for a beat before it
+    # catches up - a mismatch there just means "not yet", not a takeover, so
+    # we only start treating a mismatch as a real takeover once confirmed.
+    _pushed_media_confirmed: bool = False
+    # inputs of that push (not the built payload - see below), so a bare
+    # "play" after pausing our own local content can rebuild and re-send it
+    # instead of the station's native resume, which for our ephemeral push
+    # falls back to resuming its own last real Yandex Music (cloud) context
+    # instead of our content.
+    # Rebuilding matters: the station appears to silently ignore an
+    # audio_play directive that is byte-for-byte identical to one it already
+    # received (no new HEAD/GET ever reaches the proxy) - re-sending the
+    # exact same cached payload after a stop is a no-op. get_stream_url()
+    # signs a fresh proxy token with a new "exp" every call, so rebuilding
+    # from these inputs naturally produces a different URL string each time.
+    _last_local_media_id: Optional[str] = None
+    _last_local_media_type: Optional[str] = None
+    _last_local_metadata: Optional[dict] = None
 
     is_on: bool = None
     """Yandex TV screen state. None if device don't have this state."""
@@ -531,6 +565,12 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
 
             self.debug("Возврат в облачный режим")
             self.local_state = None
+            self._pushed_media_id = None
+            self._pushed_media_title = None
+            self._pushed_media_confirmed = False
+            self._last_local_media_id = None
+            self._last_local_media_type = None
+            self._last_local_metadata = None
 
             self._attr_assumed_state = True
             self._attr_media_artist = None
@@ -639,18 +679,58 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
             if "shuffled" in player_state["entityInfo"]:
                 self._attr_shuffle = player_state["entityInfo"]["shuffled"]
 
+            # a voice/app takeover (Алиса, включи ...) replaces our pushed
+            # content with a real Yandex Music track without ever passing
+            # through IDLE, so there's no state transition to clear
+            # _pushed_media_id on. Detect it by title mismatch instead - the
+            # station keeps echoing back the title we set in metadata for as
+            # long as our push is actually still playing.
+            if self._pushed_media_id and self._pushed_media_title:
+                if player_state["title"] == self._pushed_media_title:
+                    self._pushed_media_confirmed = True
+                elif self._pushed_media_confirmed:
+                    # was confirmed playing, now diverged without a new push
+                    # of ours - a real takeover, not just the station still
+                    # catching up right after we pushed
+                    self._pushed_media_id = None
+                    self._pushed_media_title = None
+                    self._pushed_media_confirmed = False
+                    self._last_local_media_id = None
+                    self._last_local_media_type = None
+                    self._last_local_metadata = None
+                # else: no confirmed match yet - this is the station still
+                # echoing whatever played before our push took effect, not
+                # a takeover. Keep trusting _pushed_media_id and wait.
+
             # main attributes for local mode
-            self._attr_media_content_id = player_state["id"]
+            # while we're playing our own audio_play/radio_play push, echo
+            # back the media_id we were given instead of the station's own
+            # id - external orchestrators (Music Assistant) match this
+            # against the URL they handed us to confirm they still own this
+            # stream, so their next/prev keeps routing through their queue
+            # instead of falling back to raw glagol next/prev.
+            self._attr_media_content_id = self._pushed_media_id or player_state["id"]
             self._attr_media_duration = player_state["duration"] or None
             self._attr_media_position = player_state["progress"]
             self._attr_media_position_updated_at = datetime.now(timezone.utc)
             self._attr_media_title = player_state["title"]
-            self._attr_state = (
-                MediaPlayerState.PLAYING
-                if state["playing"]
-                else MediaPlayerState.PAUSED
-            )
+            if state["playing"]:
+                self._attr_state = MediaPlayerState.PLAYING
+            else:
+                # local content we pushed ourselves has no true in-place
+                # resume (see async_media_play) - Music Assistant only
+                # rebuilds a fresh, position-accurate stream once it sees us
+                # leave PAUSED, so report idle instead of paused whenever the
+                # paused content is ours, regardless of how/when it paused.
+                self._attr_state = (
+                    MediaPlayerState.IDLE
+                    if self._last_local_media_id
+                    else MediaPlayerState.PAUSED
+                )
         else:
+            self._pushed_media_id = None
+            self._pushed_media_title = None
+            self._pushed_media_confirmed = False
             self._attr_media_content_id = None
             self._attr_media_duration = None
             self._attr_media_position = None
@@ -764,6 +844,28 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
 
     async def async_media_play(self):
         if self.local_state:
+            if self._last_local_media_id:
+                # The generic native "play" resolves against the station's own
+                # Yandex Music context, not our pushed URL - for content we
+                # pushed ourselves it would resume the last real cloud track
+                # (or nothing at all) instead, so re-send our own push here.
+                # Rebuilt rather than replayed from a cached payload: the
+                # station silently ignores an audio_play directive that is
+                # byte-for-byte identical to one it already received, and
+                # get_stream_url() signs a fresh proxy token every call.
+                payload = utils.get_stream_url(
+                    self._last_local_media_id,
+                    self._last_local_media_type,
+                    self._last_local_metadata,
+                    self.audio_client,
+                )
+                if not payload:
+                    payload = await utils.get_media_payload(
+                        self.quasar.session, self._last_local_media_id, self.audio_client
+                    )
+                if payload:
+                    await self.glagol.send(payload)
+                    return
             await self.glagol.send({"command": "play"})
 
         else:
@@ -774,6 +876,13 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
     async def async_media_pause(self):
         if self.local_state:
             await self.glagol.send({"command": "stop"})
+            if self._last_local_media_id:
+                # Report idle rather than waiting for the station's own
+                # (still "paused") confirmation - see the IDLE branch of
+                # async_set_state for why local content is always shown
+                # idle while paused, not paused.
+                self._attr_state = MediaPlayerState.IDLE
+                self.async_write_ha_state()
 
         else:
             await self.quasar.send(self.device, "пауза")
@@ -879,6 +988,12 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
             return
 
         if self.local_state:
+            # сбрасываем, пока не убедимся, что это снова наш локальный пуш -
+            # иначе после этого play_media останется мусор от предыдущего
+            self._pushed_media_id = None
+            self._pushed_media_title = None
+            self._pushed_media_confirmed = False
+
             if media_source.is_media_source_id(media_id):
                 sourced_media = await media_source.async_resolve_media(
                     self.hass, media_id, self.entity_id
@@ -890,6 +1005,12 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
                     extra.get("metadata"),
                     self.audio_client,
                 )
+                if payload:
+                    self._pushed_media_id = media_id
+                    self._pushed_media_title = (extra.get("metadata") or {}).get("title")
+                    self._last_local_media_id = sourced_media.url
+                    self._last_local_media_type = media_type
+                    self._last_local_metadata = extra.get("metadata")
 
             elif "https://" in media_id or "http://" in media_id:
                 payload = utils.get_stream_url(
@@ -899,6 +1020,12 @@ class YandexStationBase(MediaBrowser, RestoreEntity):
                     payload = await utils.get_media_payload(
                         self.quasar.session, media_id, self.audio_client
                     )
+                if payload:
+                    self._pushed_media_id = media_id
+                    self._pushed_media_title = (extra.get("metadata") or {}).get("title")
+                    self._last_local_media_id = media_id
+                    self._last_local_media_type = media_type
+                    self._last_local_metadata = extra.get("metadata")
 
             elif media_type.startswith(("text:", "dialog:")):
                 payload = {

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,11 +1,24 @@
+import asyncio
 import base64
 import json
+import time
+
+from homeassistant.components.media_player import MediaPlayerState
 
 from custom_components.yandex_station.core import stream, utils
+from custom_components.yandex_station.core import yandex_station
 
 from . import FakeYandexStation
 
 STREAM_URL = "http://192.168.1.123:8123/test.mp3"
+
+
+class FakeGlagol:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send(self, payload: dict):
+        self.sent.append(payload)
 
 
 def decode(payload: dict) -> tuple[str, dict]:
@@ -103,3 +116,303 @@ def test_audio_client_support():
         }
     )
     assert entity.audio_client is True
+
+
+def track_state(**overrides) -> dict:
+    player_state = {
+        "duration": 288.0,
+        "entityInfo": {
+            "description": "",
+            "id": "37232253",
+            "next": {"id": "", "type": "Track"},
+            "prev": {"id": "114930031", "type": "Track"},
+            "repeatMode": "None",
+            "type": "Track",
+        },
+        "extra": {"stateType": "music"},
+        "hasNext": True,
+        "hasPause": True,
+        "hasPlay": False,
+        "hasPrev": True,
+        "hasProgressBar": True,
+        "id": "STATION_OWN_ID",
+        "liveStreamText": "",
+        "playerType": "music_thin",
+        "playlistDescription": "",
+        "playlistId": "xxx",
+        "playlistPuid": "xxx",
+        "playlistType": "Track",
+        "progress": 1.0,
+        "showPlayer": False,
+        "subtitle": "",
+        "title": "Local track",
+        "type": "Track",
+    }
+    player_state.update(overrides)
+    return {
+        "aliceState": "IDLE",
+        "canStop": True,
+        "hdmi": {"capable": False, "present": False},
+        "playerState": player_state,
+        "playing": True,
+        "volume": 0.4,
+    }
+
+
+def test_pushed_media_id_echoed_as_content_id():
+    """A URL pushed via audio_play/radio_play is echoed back as media_content_id.
+
+    Music Assistant's `hass_players` provider trusts this URL match to know it
+    still owns the stream, and keeps routing next/prev through its own queue
+    instead of forwarding a raw "next"/"prev" straight to the station, which
+    would resolve it against the station's own Yandex Music context - not our
+    locally pushed playlist.
+    """
+    entity = FakeYandexStation()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+
+    entity.async_set_state({"state": track_state()})
+
+    assert entity.media_content_id == "http://mass.local/stream/abc.mp3"
+
+
+def test_real_track_uses_station_id_when_nothing_pushed():
+    """Real Yandex Music playback (voice/app) keeps the station's own id."""
+    entity = FakeYandexStation()
+
+    entity.async_set_state({"state": track_state()})
+
+    assert entity.media_content_id == "STATION_OWN_ID"
+
+
+def test_pushed_media_id_cleared_on_idle():
+    """The pushed-URL attribution must not leak into the next, unrelated session."""
+    entity = FakeYandexStation()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+
+    entity.async_set_state(
+        {"state": {"aliceState": "IDLE", "playing": False, "volume": 0.2}}
+    )
+
+    assert entity._pushed_media_id is None
+    assert entity.media_content_id is None
+
+
+def test_pushed_media_id_kept_while_title_matches():
+    """The echoed title matching what we pushed confirms it's still our stream."""
+    entity = FakeYandexStation()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+    entity._pushed_media_title = "Local track"
+
+    entity.async_set_state({"state": track_state(title="Local track")})
+
+    assert entity.media_content_id == "http://mass.local/stream/abc.mp3"
+    assert entity._pushed_media_confirmed is True
+
+
+def test_pushed_media_id_survives_stale_echo_right_after_push():
+    """Right after we push, the station may still report the previous track for
+    a beat before it catches up (e.g. re-starting the local playlist right after
+    a voice takeover). That transient mismatch must not be mistaken for a real
+    takeover - it would misreport ownership to Music Assistant for content that
+    is, in fact, correctly about to play what we just pushed.
+    """
+    entity = FakeYandexStation()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+    entity._pushed_media_title = "Local track"
+    # never confirmed yet - this is the very first update since the push
+
+    entity.async_set_state(
+        {"state": track_state(title="Previous cloud track", id="999")}
+    )
+
+    assert entity._pushed_media_id == "http://mass.local/stream/abc.mp3"
+    assert entity._pushed_media_confirmed is False
+    # still optimistically trusted, not yet fallen back to the stale station id
+    assert entity.media_content_id == "http://mass.local/stream/abc.mp3"
+
+    # the station catches up on the next update
+    entity.async_set_state({"state": track_state(title="Local track")})
+
+    assert entity._pushed_media_confirmed is True
+    assert entity.media_content_id == "http://mass.local/stream/abc.mp3"
+
+
+def test_pushed_media_id_cleared_on_voice_takeover():
+    """Voice/app playback (Алиса, включи ...) never passes through IDLE, so a
+    title mismatch is the only signal that our push is no longer playing -
+    but only once we've actually seen it confirmed at least once, otherwise
+    it's indistinguishable from the station still catching up on our push.
+    """
+    entity = FakeYandexStation()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+    entity._pushed_media_title = "Local track"
+
+    # confirm our push actually took effect first
+    entity.async_set_state({"state": track_state(title="Local track")})
+    assert entity._pushed_media_confirmed is True
+
+    # then something else takes over
+    entity.async_set_state(
+        {"state": track_state(title="Some real Yandex Music track", id="123456")}
+    )
+
+    assert entity._pushed_media_id is None
+    assert entity._pushed_media_title is None
+    assert entity._pushed_media_confirmed is False
+    assert entity.media_content_id == "123456"
+
+
+def test_resume_replays_local_push_instead_of_native_play():
+    """The station's native "play" resumes its own last real Yandex Music
+    (cloud) session, not our externally pushed URL - so resuming our own
+    paused local content must re-send our push instead of that bare command.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": False}
+    entity.glagol = FakeGlagol()
+    entity._last_local_media_id = STREAM_URL
+    entity._last_local_media_type = "music"
+
+    asyncio.run(entity.async_media_play())
+
+    assert len(entity.glagol.sent) == 1
+    name, data = decode(entity.glagol.sent[0])
+    assert name == "radio_play"
+    assert ".mp3" in data["streamUrl"]
+
+
+def test_resume_rebuilds_a_fresh_payload_not_a_stale_replay(monkeypatch):
+    """Regression: the station silently ignores an audio_play/radio_play
+    directive that is byte-for-byte identical to one it already received -
+    no new request ever reaches the proxy for it. Caching and re-sending the
+    exact original payload was therefore a no-op on a second resume;
+    get_stream_url() must be called again so each resume signs a fresh URL
+    (the proxy token embeds an "exp" timestamp, which is what makes two
+    otherwise-identical resumes produce different bytes on the wire).
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": False}
+    entity.glagol = FakeGlagol()
+    entity._last_local_media_id = STREAM_URL
+    entity._last_local_media_type = "music"
+
+    real_time = time.time
+    monkeypatch.setattr(stream.time, "time", lambda: real_time() + 1)
+    asyncio.run(entity.async_media_play())
+    monkeypatch.setattr(stream.time, "time", lambda: real_time() + 2)
+    asyncio.run(entity.async_media_play())
+
+    assert len(entity.glagol.sent) == 2
+    assert entity.glagol.sent[0] != entity.glagol.sent[1]
+
+
+def test_resume_replays_local_push_after_pause_cleared_pushed_media_id():
+    """Regression: pausing our push (glagol "stop") drops the station's
+    playerState entirely, same as genuine idle - which already clears
+    _pushed_media_id (it governs whether we still echo ownership to MA).
+    Resume must not additionally require _pushed_media_id, only the cached
+    local-push inputs need to survive a pause, or resume silently falls back
+    to the broken native "play" every time.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": True}
+    entity.glagol = FakeGlagol()
+    entity._pushed_media_id = "http://mass.local/stream/abc.mp3"
+    entity._pushed_media_title = "Local track"
+    entity._last_local_media_id = STREAM_URL
+    entity._last_local_media_type = "music"
+
+    # pausing (glagol "stop") - the station reports no playerState at all
+    entity.async_set_state(
+        {"state": {"aliceState": "IDLE", "playing": False, "volume": 0.2}}
+    )
+    assert entity._pushed_media_id is None
+    assert entity._last_local_media_id == STREAM_URL  # must survive the pause
+
+    asyncio.run(entity.async_media_play())
+
+    assert len(entity.glagol.sent) == 1
+    name, _ = decode(entity.glagol.sent[0])
+    assert name == "radio_play"
+
+
+def test_resume_uses_native_play_without_a_local_push():
+    """Nothing of ours was pushed (or a voice takeover was detected) - the
+    native command is correct here, it resumes real Yandex Music playback.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": False}
+    entity.glagol = FakeGlagol()
+
+    asyncio.run(entity.async_media_play())
+
+    assert entity.glagol.sent == [{"command": "play"}]
+
+
+def test_pause_reports_idle_immediately_for_local_content(monkeypatch):
+    """Regression: Music Assistant's own resume only rebuilds a fresh,
+    position-accurate stream (player_queues/controller.py's _handle_play)
+    once it sees the queue leave PAUSED - while we still show paused, it
+    instead forwards a bare native "play", which for local content replays
+    our last push from the start (see async_media_play), losing position.
+    This used to be worked around with a 32s delayed idle-flip on the
+    (wrong) theory that only long pauses were affected - in fact every
+    resume attempted while we still show paused hits this, regardless of
+    pause duration, so we now report idle immediately instead of waiting.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": True}
+    entity.glagol = FakeGlagol()
+    entity._last_local_media_id = STREAM_URL
+    write_calls = []
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: write_calls.append(1))
+
+    asyncio.run(entity.async_media_pause())
+
+    assert entity.glagol.sent == [{"command": "stop"}]
+    assert entity._attr_state == MediaPlayerState.IDLE
+    assert write_calls == [1]
+
+
+def test_pause_does_not_force_idle_without_local_content(monkeypatch):
+    """Real Yandex Music (voice/app) playback has a genuine native pause -
+    there's no rebuild-on-resume fallback here to protect.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": True}
+    entity.glagol = FakeGlagol()
+    write_calls = []
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: write_calls.append(1))
+
+    asyncio.run(entity.async_media_pause())
+
+    assert entity.glagol.sent == [{"command": "stop"}]
+    assert write_calls == []
+
+
+def test_set_state_reports_idle_not_paused_for_local_content():
+    """The station's own confirmatory playerState push after our "stop"
+    (still "paused" device-side) must not flip the reported state back to
+    paused - that would silently reopen the resume-loses-position bug this
+    idle reporting exists to prevent, for as long as the push survives.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": True}
+    entity._last_local_media_id = STREAM_URL
+
+    entity.async_set_state({"state": {**track_state(), "playing": False}})
+
+    assert entity.state == MediaPlayerState.IDLE
+
+
+def test_set_state_reports_paused_without_local_content():
+    """Real Yandex Music (voice/app) playback has a genuine native pause -
+    it should still show as paused, not idle.
+    """
+    entity = FakeYandexStation()
+    entity.local_state = {"aliceState": "IDLE", "playing": True}
+
+    entity.async_set_state({"state": {**track_state(), "playing": False}})
+
+    assert entity.state == MediaPlayerState.PAUSED


### PR DESCRIPTION
Продолжение #802 (директива `audio_play`). Как только колонку начинает кормить внешний
оркестратор вроде Music Assistant, который пушит сырые HTTP-ссылки на поток вместо реальных
track ID из Яндекс.Музыки — вылезают три смежные проблемы. Все они из-за того, что колонка
никак не сигнализирует, что именно сейчас проигрывается «наше» или уже что-то другое, и как
себя вести при паузе/резюме такого контента.

## Что было не так и как исправлено

**1. Кнопки next/prev на локальном треке уводили на случайный трек Яндекс.Музыки.**
Причина: `media_content_id` всегда отдавался внутренний ID колонки, а не тот URL, который
реально был запущен. Из-за этого оркестратор не мог опознать «это всё ещё я играю» (он сверяет
свой URL с тем, что отдаёт entity) и откатывался на голые команды `next`/`prev`, которые колонка
резолвит уже в своём облачном контексте Яндекс.Музыки.
Фикс: пока идёт наш локальный пуш, честно отдаём его же `media_id` обратно в
`media_content_id` — оркестратор узнаёт свой URL и ведёт next/prev через свою очередь.

**2. Голосовой перехват («Алиса, включи ...») не определялся.**
После того как что-то другое реально забрало колонку себе, entity всё ещё считала, что играет
её контент — нет события IDLE, на которое можно было бы опереться. Определяем перехват по
несовпадению title (то, что мы отправили, против того, что реально отдаёт колонка), но только
после того как одно совпадение уже было зафиксировано — иначе можно словить ложный "перехват"
в первую секунду после собственного пуша, пока колонка ещё отдаёт título предыдущего трека.

**3. Пауза/резюме локального контента возвращали трек с начала, теряя позицию.**
- Родная команда "play" резюмит собственный Яндекс.Музыка-контекст колонки, а не наш пуш —
  пришлось резюмить пуш вручную (пересылкой того же payload).
- Колонка молча игнорирует повторную `audio_play`/`radio_play` директиву, если она
  побайтово совпадает с уже полученной — поэтому payload теперь всегда собирается заново
  (`get_stream_url`/`get_media_payload`), это даёт свежий токен на каждый вызов.
- Самое неочевидное: для пуша извне нет настоящего resume "на месте" — на паузе колонка
  останавливается полностью (`stop`), так что резюм обязан быть свежим пушем, а не голым "play".
  Внешний оркестратор берёт свой точный по позиции путь резюма только увидев, что наше HA-состояние
  вышло из "paused" — а мы стояли в "paused" сколько угодно долго. Поэтому пока мы пуш держим на
  паузе, отдаём "idle" вместо "paused" — это гарантированно заводит резюм через точный по позиции
  путь оркестратора.

**Плюс отдельный, более мелкий фикс** в проксирующем стриме (`core/stream.py`): убран таймаут
чтения между чанками (`sock_read`) — он рассчитывался на файловый сервер, отдающий данные сразу,
а Music Assistant в потоковом режиме намеренно придерживает скорость отдачи (антизлоупотребление
на своей стороне). Из-за таймаута прокси рвал соединение на каждой естественной паузе между
чанками длиннее 10 секунд, колонка переподключалась, а MA перезапускал стрим с нуля, теряя
позицию в очереди.

## Как проверялось

Диагностировано с реальными логами на живом развёртывании (HA + Music Assistant), плюс сверкой
с исходниками `music-assistant/server` для понимания его стороны логики очереди/резюма. Добавлены
модульные тесты на новое поведение (`tests/test_stream.py`).

Прогон полного набора тестов: все проходят, кроме двух заранее существующих провалов в
`test_light.py` (расхождение версии установленного Home Assistant с тем, под который писались
тесты) — не связаны с этим PR, воспроизводятся и на чистом `master` без этих изменений.

**Пока проверено на одной реальной колонке Яндекс Станции Мини.**

## Дисклеймер

Я не программирую на Python — код и тесты в этом PR написаны с помощью Claude (Anthropic) под
моим руководством, с диагностикой по реальным логам живого стенда и итеративной проверкой на
собственной колонке. Готов оперативно проверить любые правки, которые попросит мейнтейнер.
