### PR TITLE
Fix light color mode on HA 2026.6+ (#759)

### DIFF
--- a/custom_components/yandex_station/light.py
+++ b/custom_components/yandex_station/light.py
@@ -78,8 +78,16 @@ class YandexLight(LightEntity, YandexEntity):
                 self._attr_effect_list = [i["name"] for i in self.effects]
                 self._attr_supported_features = LightEntityFeature.EFFECT
 
-            self._attr_color_mode = None
-            self._attr_supported_color_modes = modes
+            # color capability may have scenes only, keep brightness/onoff then
+            if modes:
+                self._attr_supported_color_modes = modes
+                # HA no longer resolves color_mode=None from entity attributes,
+                # it has to be one of the supported modes
+                self._attr_color_mode = (
+                    ColorMode.COLOR_TEMP
+                    if ColorMode.COLOR_TEMP in modes
+                    else next(iter(modes))
+                )
 
     def internal_update(self, capabilities: dict, properties: dict):
         if self.on_instance in capabilities:


### PR DESCRIPTION
Продолжение #759. После 3.22.0 старая ошибка ушла, но на HA 2026.6.4 сущность цветной лампы по-прежнему не создаётся — просто с другим текстом:

```
homeassistant.exceptions.HomeAssistantError: light.yandex_lightstrip (<class 'custom_components.yandex_station.light.YandexLight'>) does not report a color mode
```

Причина — `self._attr_color_mode = None` в конце `internal_init`. Раньше это означало «HA, выведи режим сам по атрибутам», но в свежих версиях этот путь убран: если `supported_color_modes` заполнен, `color_mode` обязан быть одним из режимов набора.

В PR ставится явный режим из набора, `COLOR_TEMP` в приоритете. Значение стартовое: `internal_update` дальше переставляет режим на `HS` или `COLOR_TEMP` по фактическому состоянию устройства.

Проверка `if modes:` заодно закрывает второй случай. Сейчас `modes` создаётся внутри `if color:` и там же присваивается в `supported_color_modes`. Если у устройства в `color` есть только `scenes` — без `palette` и без `temperature_k` — набор останется пустым, и сущность не создастся уже из-за пустого `supported_color_modes`. С проверкой в этом случае остаётся режим `brightness`/`onoff`, выставленный выше.

Проверено на светодиодной ленте Яндекса (палитра + температура), HA 2026.6.4: сущность создаётся, `color_mode` = `color_temp`, `supported_color_modes` = `[color_temp, hs]`, включение и выключение работают и из HA, и голосом. Устройства со сценами без палитры проверить не на чем — там правка безопасна логически, но вживую я её не гонял.